### PR TITLE
color icon white if unit is selected

### DIFF
--- a/LuaUI/Widgets/gui_mcl_healthbar.lua
+++ b/LuaUI/Widgets/gui_mcl_healthbar.lua
@@ -464,9 +464,13 @@ function widget:DrawWorld()
 	
 						if ICON_TYPE[udid] and alpha > 0.3 then
 							glColor(r,g,b,alpha)
+							if IsUnitSelected(uid) then
+								glColor(1,1,1,alpha)
+							end
 							glTex(ICON_TYPE[udid])
 							glTexRect(radius*-0.65-(16 * heightscale), -8*heightscale, radius*-0.65, 8*heightscale)
 							glTex(false)
+							glColor(r,g,b,alpha)
 						end
 				end
 				if display then


### PR DESCRIPTION
icons are white if selected when zoomed out far, but when zoomed in the selected unit icons switch to teamcolor. This draws selected unit icons white when zoomed in for consistency